### PR TITLE
Update go get instructions to point at the new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A tool for monitoring beanstalk queues. Based on 'bsa' https://github.com/davidp
 
 ## Install
 
-    $ go get github.com/george-infinity/bsw
+    $ go get github.com/gha/bsw
 
 ## Usage
 


### PR DESCRIPTION
This commit updates the `go get` path from `george-infinity/bsw` to `gha/bsw` as the path to the repository was changed.